### PR TITLE
bug 2e test de itoa

### DIFF
--- a/src/test_functions.c
+++ b/src/test_functions.c
@@ -6,7 +6,7 @@
 /*   By: alelievr <alelievr@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created  2015/11/17 17:42:18 by alelievr          #+#    #+#             */
-/*   Updated: 2016/12/24 17:07:49 by bwaegene         ###   ########.fr       */
+/*   Updated: 2017/01/16 17:56:39 by tjeanner         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -6265,7 +6265,7 @@ void			test_ft_itoa_random(void *ptr) {
 				n = rand();
 				d = ft_itoa(n);
 				if (atoi(d) != n) {
-					SET_DIFF_INT(atoi(d), n)
+					SET_DIFF_INT(n, atoi(d))
 					exit(TEST_FAILED);
 				}
 			}


### PR DESCRIPTION
Hello,
j'ai trouvé une erreur dans le fichier test_functions.c pour la fonction ft_itoa. En effet dans le test 2 le chiffre testé (n) et le résultat de ft_itoa traité par atoi (atoi(d)) ont été inversés. Cela peut résulter, lorsque la fonction ft_itoa n'est pas correcte, d'une totale incompréhension de l'erreur.