### PR TITLE
Fixing library compilation multiple threads error.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -217,7 +217,7 @@ libclean:
 	@rm -rf $(ASSETDIR)/$(ANAME) $(ASSETDIR)/$(NAME) $(TMPLIB)
 
 relib:
-	@$(call exec_color, "\033[38;5;$(LINK_COLOR_T)m", make -j 3 re -C "$(LIBFTDIR)")
+	@$(call exec_color, "\033[38;5;$(LINK_COLOR_T)m", make re -C "$(LIBFTDIR)")
 
 #	All removing then compiling
 re: relib fclean libclean all


### PR DESCRIPTION
Hi!
I had an issue with the 42filechecker (which uses your program), because of multiple threads during the compilation the ar command started too early and failed. When I used your program alone the compilation worked randomly but never inside the 42filechecker process. Because the compilation process isn't too long I thought the -j option might be skipped.
Thanks for your program, it's awesome!
All the best.