### PR TITLE
Fixed Makefile so at line 162

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,7 +159,7 @@ $(SONAME):
 		$(CC_SO), $(CSOFLAGS), $(TMPLIB)/*.o, -o, $(SONAME))
 else
 $(SONAME):
-	@make -C $(LIBFTDIR) so
+	@gcc -shared -o $(LIBFTDIR)/$(SONAME) -fPIC $(LIBFTDIR)/*.c
 	@if [ -e $(LIBFTDIR)/libft.so ];\
 		then\
 		cp $(LIBFTDIR)/libft.so . ;\


### PR DESCRIPTION
First of all thanks for this awesome test for libft,
I managed to install it correctly on the school's Macs but found and issue at home on WSL.
I work on Windows 10 with WSL and found this small error in the makefile that would not compile the .so file.

Error:

Line 162 in Makefile:	@make -C $(LIBFTDIR) so

Error:	make[1]: *** No rule to make target 'so'.  Stop.
	        &emsp; &emsp; make: *** [Makefile:162: libft.so] Error 2

Fix:

Line 162 in Makefile:	@gcc -shared -o $(LIBFTDIR)/$(SONAME) -fPIC $(LIBFTDIR)/*.c