### PR TITLE
Adding crush tests for ft_strlcat and ft_strnstr

### DIFF
--- a/src/test_functions.c
+++ b/src/test_functions.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   test_functions.c                                   :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: user42 <user42@student.42.fr>              +#+  +:+       +#+        */
+/*   By: mfunyu <mfunyu@student.42tokyo.jp>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2015/11/17 17:42:18 by alelievr          #+#    #+#             */
-/*   Updated: 2020/07/03 15:35:48 by user42           ###   ########.fr       */
+/*   Updated: 2022/08/23 21:29:47 by mfunyu           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -3020,6 +3020,19 @@ void			test_ft_strlcat_speed(void *ptr) {
 			);
 }
 
+void			test_ft_strlcat_null3(void *ptr) {
+	typeof(strlcat)	*ft_strlcat = ptr;
+	SET_EXPLANATION("your strlcat crush when null parameter is sent with a size of 0");
+
+	SANDBOX_RAISE(
+			char	b[0xF] = "nyan !";
+
+			ft_strlcat(NULL, b, 0);
+
+			exit(TEST_SUCCESS);
+			);
+}
+
 void            test_ft_strlcat(void){
 	add_fun_subtest(test_ft_strlcat_basic);
 	add_fun_subtest(test_ft_strlcat_return);
@@ -3033,6 +3046,7 @@ void            test_ft_strlcat(void){
 	add_fun_subtest(test_ft_strlcat_return_value);
 	add_fun_subtest(test_ft_strlcat_null1);
 	add_fun_subtest(test_ft_strlcat_null2);
+	add_fun_subtest(test_ft_strlcat_null3);
 	add_fun_subtest(test_ft_strlcat_speed);
 }
 
@@ -7934,7 +7948,7 @@ void			test_ft_lstsize_basic(void *ptr) {
 			t_list	*l;
 			int actual;
 			int expected;
-	
+
 			l = lstnew(strdup("1"));
 			l->next = lstnew(strdup("2"));
 			l->next->next = lstnew(strdup("3"));
@@ -7955,7 +7969,7 @@ void			test_ft_lstsize_null(void *ptr) {
 			t_list	*l = NULL;
 			int actual;
 			int expected = 0;
-	
+
 			actual = ft_lstsize(l);
 			if (actual == expected)
 				exit(TEST_SUCCESS);
@@ -7981,7 +7995,7 @@ void			test_ft_lstlast_basic(void *ptr) {
 			t_list	*l;
 			t_list	*expected;
 			t_list	*actual;
-	
+
 			l = lstnew(strdup("1"));
 			l->next = lstnew(strdup("2"));
 			l->next->next = lstnew(strdup("3"));

--- a/src/test_functions.c
+++ b/src/test_functions.c
@@ -6,7 +6,7 @@
 /*   By: mfunyu <mfunyu@student.42tokyo.jp>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2015/11/17 17:42:18 by alelievr          #+#    #+#             */
-/*   Updated: 2022/08/23 21:29:47 by mfunyu           ###   ########.fr       */
+/*   Updated: 2022/08/23 21:40:16 by mfunyu           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -3932,6 +3932,16 @@ void			test_ft_strnstr_speed(void *ptr) {
 			);
 }
 
+void			test_ft_strnstr_null3(void *ptr) {
+	typeof(strnstr)	*ft_strnstr = ptr;
+	SET_EXPLANATION("your strnstr crush when null parameter is sent with a size of 0");
+
+	SANDBOX_RAISE(
+			ft_strnstr(NULL, "fake", 0);
+			exit(TEST_SUCCESS);
+			);
+}
+
 void            test_ft_strnstr(void){
 	add_fun_subtest(test_ft_strnstr_basic);
 	add_fun_subtest(test_ft_strnstr_basic2);
@@ -3947,6 +3957,7 @@ void            test_ft_strnstr(void){
 	add_fun_subtest(test_ft_strnstr_electric_memory);
 	add_fun_subtest(test_ft_strnstr_null2);
 	add_fun_subtest(test_ft_strnstr_null1);
+	add_fun_subtest(test_ft_strnstr_null3);
 	add_fun_subtest(test_ft_strnstr_speed);
 }
 


### PR DESCRIPTION
- #128

## What
- Added null test functions for `ft_strlcat` and `ft_strnstr` to test `func(NULL, "str, 0)` case 
( case 3 in the table below )

| |   `strlcat` |  | `strnstr` |
| -- | -- | :--: | -- | 
| 1 | strlcat(NULL, "abc", 1); |  crush | strnstr(NULL, "abc", 1);
| 2 | strlcat("abc", NULL, 0); | crush | strnstr("abc", NULL, 0); 
| 3 | strlcat(NULL, "abc", 0); | must not crush | strnstr(NULL, "abc", 0);


## Why
- This is an edge case that students are likely to miss.
- Since 2 NULL tests ( case 1 and 2 in the table above ) already exist on both functions, students tend to overlook the fact that there is another case to be met.


### Notes

- Thank you very much for your time and dedication to keep updating this test. I was once saved by this test, and I still appreciate and admire your motivation in creating this test! 