### PR TITLE
Fix defining calloc as receiving only one parameter

### DIFF
--- a/src/test_functions.c
+++ b/src/test_functions.c
@@ -1740,11 +1740,11 @@ void            test_ft_strdup(void) {
 ////////////////////////////////
 
 void			test_ft_calloc_free(void *ptr) {
-	void *	(*ft_calloc)(size_t) = ptr;
+	typeof(calloc)	*ft_calloc = ptr;
 	SET_EXPLANATION("your calloc don't allocate memory");
 
 	SANDBOX_RAISE(
-			free(ft_calloc(42));
+			free(ft_calloc(42, 1));
 			);
 }
 


### PR DESCRIPTION
The first calloc test in libft-unit-test tester timeouts on my laptop but not in school.

I looked at the test, and I think that the problem is in the test rather than in my code. In all other calloc tester functions the pointer to the tested function is casted to `typeof(calloc)*` like [this](https://github.com/xicodomingues/libft-unit-test/blob/f3af320e6b6e94b87b0cdee74761d2bd19bd202b/src/test_functions.c#L1752) but in `test_ft_calloc_free` it is casted to `void *(*)(size_t)` like [this](https://github.com/xicodomingues/libft-unit-test/blob/f3af320e6b6e94b87b0cdee74761d2bd19bd202b/src/test_functions.c#L1743). Later it [is called](https://github.com/xicodomingues/libft-unit-test/blob/f3af320e6b6e94b87b0cdee74761d2bd19bd202b/src/test_functions.c#L1747) with one param. But that's UB because `ft_calloc` has 2 params.

I suggest replacing
```c
void *	(*ft_calloc)(size_t) = ptr;
...
free(ft_calloc(42));
```
with
```c
typeof(calloc)	*ft_calloc = ptr;
...
free(ft_calloc(42, 1));
```
or whatever value of the second parameter makes sense.

First reported here by @Oktosha
https://github.com/xicodomingues/francinette/issues/15