### PR TITLE
test_ft_lstdelone_nulls: don't stupidly double-free the node.

### DIFF
--- a/src/test_functions.c
+++ b/src/test_functions.c
@@ -6,7 +6,7 @@
 /*   By: mfunyu <mfunyu@student.42tokyo.jp>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2015/11/17 17:42:18 by alelievr          #+#    #+#             */
-/*   Updated: 2022/10/30 09:25:38 by ladloff          ###   ########.fr       */
+/*   Updated: 2022/11/12 00:01:28 by twalker          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -7460,7 +7460,6 @@ void			test_ft_lstdelone_nulls(void *ptr) {
 
 			ft_lstdelone(NULL, lstdelone_f);
 			ft_lstdelone(node, NULL);
-			free(node);
 			);
 }
 


### PR DESCRIPTION
ft_lstdelone

Takes as a parameter a node and

- frees the memory of the node’s content using the function ’del’ given as a parameter and

- free the node. // using ***free*** duh! del is used to free the content, not the node; the node was obviously allocated w/malloc via ft_lstnew and should therefore be deallocated using free, not del; consequently, del being NULL has no effect whatsoever on ft_lstdelone's ability to free the node itself…

Thus (a working) ft_lstdelone(node, NULL) already freed the node.