### PR TITLE
memcpy: test for one NULL param and size 0.

### DIFF
--- a/src/test_functions.c
+++ b/src/test_functions.c
@@ -6,7 +6,7 @@
 /*   By: mfunyu <mfunyu@student.42tokyo.jp>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2015/11/17 17:42:18 by alelievr          #+#    #+#             */
-/*   Updated: 2022/10/30 09:25:38 by ladloff          ###   ########.fr       */
+/*   Updated: 2022/11/11 21:58:23 by twalker          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -458,6 +458,24 @@ void			test_ft_memcpy_null2(void *ptr) {
 			);
 }
 
+void			test_ft_memcpy_null3(void *ptr) {
+	typeof(memcpy)	*ft_memcpy = ptr;
+	SET_EXPLANATION("your memcpy should not crash with NULL as one of the params when size is 0");
+
+	SANDBOX_RAISE(
+			ft_memcpy(NULL, "", 0);
+			);
+}
+
+void			test_ft_memcpy_null4(void *ptr) {
+	typeof(memcpy)	*ft_memcpy = ptr;
+	SET_EXPLANATION("your memcpy should not crash with NULL as one of the params when size is 0");
+
+	SANDBOX_RAISE(
+			ft_memcpy("", NULL, 0);
+			);
+}
+
 void			test_ft_memcpy_double_null1(void *ptr) {
 	typeof(memcpy)	*ft_memcpy = ptr;
 	SET_EXPLANATION("your memcpy does not behave well with NULL as both params");
@@ -501,6 +519,8 @@ void            test_ft_memcpy(void){
 	add_fun_subtest(test_ft_memcpy_electric_memory);
 	add_fun_subtest(test_ft_memcpy_null1);
 	add_fun_subtest(test_ft_memcpy_null2);
+	add_fun_subtest(test_ft_memcpy_null3);
+	add_fun_subtest(test_ft_memcpy_null4);
 	add_fun_subtest(test_ft_memcpy_double_null1);
 	add_fun_subtest(test_ft_memcpy_double_null2);
 	add_fun_subtest(test_ft_memcpy_speed);


### PR DESCRIPTION
A "typical" memcpy will not crash (because of the zero size).

Even though this is, AFAICT, actually undefined behavior, Lausanne's moulinette appears to do a similar test, so it's probably a good idea to consider it an error in a libft tester as well.

Some students cannot figure out how/why memcpy crashes "naturally" and come up with creative ways to do it forcibly instead; but as a result their ft_memcpy may crash even in cases where a "typical" implementation of memcpy wouldn't. This catches some of them.

Example failing implementation of memcpy: https://gist.github.com/Rodeo314/c4a52a902acf60336203c90f04b9a31d