### PR TITLE
Fixed a problem that always crashes when executing `ft_strrchr` test code.

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -3,7 +3,7 @@
 /*                                                        :::      ::::::::   */
 /*   main.c                                             :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: knagase <knagase@student.42tokyo.jp>       +#+  +:+       +#+        */
+/*   By: alelievr <alelievr@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2015/11/13 19:59:29 by alelievr          #+#    #+#             */
 /*   Updated: 2023/01/19 03:24:35 by knagase          ###   ########.fr       */

--- a/src/main.c
+++ b/src/main.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   main.c                                             :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: alelievr <alelievr@student.42.fr>          +#+  +:+       +#+        */
+/*   By: knagase <knagase@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2015/11/13 19:59:29 by alelievr          #+#    #+#             */
-/*   Updated: 2019/10/20 11:01:10 by juligonz         ###   ########.fr       */
+/*   Updated: 2023/01/19 03:24:35 by knagase          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -41,20 +41,22 @@ static t_option options[] = {
 
 void	*electric_alloc(size_t size)
 {
-	void	*ptr = mmap(NULL, 8192lu, PROT_READ | PROT_WRITE, MAP_ANON | MAP_PRIVATE, -1, 0);
+	long	page_size = sysconf(_SC_PAGESIZE);
+	void	*ptr = mmap(NULL, page_size * 2, PROT_READ | PROT_WRITE, MAP_ANON | MAP_PRIVATE, -1, 0);
 
-	memset(ptr, 'Z', 8192lu);
-	mprotect(ptr + 4096, 4096, PROT_NONE);
-	return (ptr + 4096 - size);
+	memset(ptr, 'Z', page_size * 2);
+	mprotect(ptr + page_size, page_size, PROT_NONE);
+	return (ptr + page_size - size);
 }
 
 void	*electric_alloc_rev(size_t size)
 {
-	void	*ptr = mmap(NULL, 8192lu, PROT_READ | PROT_WRITE, MAP_ANON | MAP_PRIVATE, -1, 0);
+	long	page_size = sysconf(_SC_PAGESIZE);
+	void	*ptr = mmap(NULL, page_size * 2, PROT_READ | PROT_WRITE, MAP_ANON | MAP_PRIVATE, -1, 0);
 
-	memset(ptr, 'Z', 8192lu);
-	mprotect(ptr, 4096, PROT_NONE);
-	return (ptr + 4096 + size);
+	memset(ptr, 'Z', page_size * 2);
+	mprotect(ptr, page_size, PROT_NONE);
+	return (ptr + page_size + size);
 }
 
 unsigned long long	ft_clock(void) {


### PR DESCRIPTION
Testing `ft_strrchr` always crushes with `test_ft_strrchr_electric_memory`.

```
ft_strrchr:    [OK] [OK] [OK] [OK] [OK] [OK] [CRASH] [OK] 
[crash]: your strrchr crash because it read too many bytes or attempt to write on s !
Test code:
	char *src = electric_alloc(10);

	__builtin___strcpy_chk (src, "123456789", __builtin_object_size (src, 2 > 1 ? 1 : 0));
	ft_strrchr(src, 'a');
	src = electric_alloc_rev(10);
	__builtin___strcpy_chk (src, "123456789", __builtin_object_size (src, 2 > 1 ? 1 : 0));
	ft_strrchr(src, 'a');
	exit(TEST_SUCCESS);
```

Upon investigation, I found that it was due to `mprotect(ptr, 4096, PROT_NONE);` in the `electric_alloc_rev` function.
I measured the page size on my Macbook pro m1 with the following code and it was `16384`.

```c
long page_size = sysconf(_SC_PAGESIZE);
```

So it should be `mprotect(ptr, 16384, PROT_NONE);`.
After modifying the code to allocate memory space based on page size, this problem no longer occurs.